### PR TITLE
Fix Prisma DATABASE_URL setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Para ejecutar el proyecto con Docker:
 
-1. Copia `reserva-hotel-backend/.env.example` a `reserva-hotel-backend/.env` y ajusta las variables si es necesario.
+1. Copia `reserva-hotel-backend/.env.example` a `reserva-hotel-backend/.env` y ajusta las variables si es necesario. Asegúrate de que `DATABASE_URL` contenga la cadena de conexión completa.
 2. Construye y levanta los contenedores:
 
 ```bash

--- a/reserva-hotel-backend/.env.example
+++ b/reserva-hotel-backend/.env.example
@@ -3,3 +3,4 @@ DATABASE_PORT=5432
 DATABASE_USER=nest_user
 DATABASE_PASSWORD=nest_pass
 DATABASE_NAME=nest_db
+DATABASE_URL=postgresql://nest_user:nest_pass@postgres:5432/nest_db


### PR DESCRIPTION
## Summary
- update `.env.example` to include `DATABASE_URL`
- note the connection string in README instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bddffb7848325bd5f66cddd6f9e13